### PR TITLE
Fetch a random question when question is not found

### DIFF
--- a/src/routes/Game/index.jsx
+++ b/src/routes/Game/index.jsx
@@ -131,7 +131,7 @@ class GamePage extends React.Component {
         if (isNumber(questionId) && unmask(questionId) <= nextProps.questionCount) {
           this.fetchQuestion(unmask(questionId));
         } else {
-          this.handleQuestionNotFound();
+          this.handleQuestionNotFound(nextProps.questionCount);
         }
       } else {
         // The first question in the stack
@@ -144,7 +144,7 @@ class GamePage extends React.Component {
     this.unlistenForHistory();
   }
 
-  handleQuestionNotFound() {
+  handleQuestionNotFound(questionCount) {
     const { createSnackbar } = this.props;
 
     // Notify the user
@@ -154,7 +154,7 @@ class GamePage extends React.Component {
     });
 
     // Fetch a new question
-    this.fetchRandomQuestion(undefined, true);
+    this.fetchRandomQuestion(questionCount, true);
   }
 
   pushQuestionToHistory(id) {


### PR DESCRIPTION
There was a bug that annoyed me for a while but I ignored it for a while: when a question is not found, for example when providing an invalid / non-existing id, the first question would be fetched.

The proper behavior (and what was stated on the UI) is that a random question would be fetched. This was a simple yes sneaky bug.  'componentWillReceiveProps' is indeed a bad pattern.